### PR TITLE
Allow domains with MX but no A or AAAA

### DIFF
--- a/filter-checksenderdomain.go
+++ b/filter-checksenderdomain.go
@@ -67,7 +67,12 @@ func resolveDomain(sessionId string, token string, domain string) {
 	if err == nil {
 		produceOutput("filter-result", sessionId, token, "proceed")
 	} else {
-		produceOutput("filter-result", sessionId, token, "reject|550 unknown sender domain")
+		_, err := net.LookupMX(domain)
+		if err == nil {
+			produceOutput("filter-result", sessionId, token, "proceed")
+		} else {
+			produceOutput("filter-result", sessionId, token, "reject|550 unknown sender domain")
+		}
 	}
 }
 


### PR DESCRIPTION
Also allow domains that have an MX record but no A or AAAA record (those are still able to receive email so I'd consider them legitimate sender domains).